### PR TITLE
Crashfix on /meta set <variable name> without new value

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -232,7 +232,7 @@ minetest.register_chatcommand("meta", {
 
 			if not paramlist[3] then
 				minetest.chat_send_player(name,"- meta::set - You must provide a value for the variable you want to set")
-				minetest.log("action","[metatools] Player "..name.." failed setting variable ".. paramlist[3] .." : no value given")
+				minetest.log("action","[metatools] Player "..name.." failed setting variable ".. paramlist[2] .." : no value given")
 				return false
 			end
 


### PR DESCRIPTION
This was just caused by a little typo (`paramlist[3]` instead of `paramlist[2]`).
